### PR TITLE
change ceiling and floor price to percentage

### DIFF
--- a/hummingbot/strategy/pure_market_making/pure_market_making.pyx
+++ b/hummingbot/strategy/pure_market_making/pure_market_making.pyx
@@ -811,9 +811,11 @@ cdef class PureMarketMakingStrategy(StrategyBase):
             self.c_apply_ping_pong(proposal)
 
     cdef c_apply_price_band(self, proposal):
-        if self._price_ceiling > 0 and self.get_price() >= self._price_ceiling:
+        price_ceiling = ((self._price_ceiling_pct * self.get_price())/100) + self.get_price()
+        if price_ceiling > 0 and self.get_price() >= price_ceiling:
             proposal.buys = []
-        if self._price_floor > 0 and self.get_price() <= self._price_floor:
+        price_floor = self.get_price() - (self._price_floor_pct * self.get_price()/100)
+        if price_floor > 0 and self.get_price() <= price_floor:
             proposal.sells = []
 
     cdef c_apply_ping_pong(self, object proposal):


### PR DESCRIPTION
New set up via choosing a percentage for floor and ceiling instead of price


Regarding the request for "price_band_refresh_time", looks redundant as price bands are reset based on the current price ("get_price") every-time "order_refresh_time" is checked while send orders for PMM

